### PR TITLE
Harden Redis connection lifecycle to prevent Render crash loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,12 +183,15 @@ VITE_AUTH0_CLIENT_ID=
 VITE_AUTH0_AUDIENCE=
 
 # Optional
-REDIS_URL=
+# Use rediss:// for managed Redis providers that require TLS (Render/Upstash/etc.)
+REDIS_URL=rediss://<user>:<password>@<host>:<port>
 PORT=5000
 NODE_ENV=development
 ```
 
 *(See `.env.<production/development>.example` for full details.)*
+
+If `REDIS_URL` is missing or Redis is unavailable, the API boots in degraded mode and skips Redis-backed features where possible.
 
 ---
 

--- a/server/src/config/rateLimiter.ts
+++ b/server/src/config/rateLimiter.ts
@@ -31,7 +31,8 @@ export function createRateLimiter(
     logger.info("Using Redis store for rate limiting");
     return rateLimit({
       store: new RedisStore({
-        sendCommand: (...args: string[]) => redisClient.sendCommand(args),
+        sendCommand: (...args: string[]) =>
+          redisClient.sendCommand(args) as Promise<any>,
       }),
       windowMs: options.windowMs,
       max: options.max,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -14,5 +14,14 @@ dotenv.config({
   override: false,
 });
 
+
+process.on("unhandledRejection", (reason) => {
+  console.error("Unhandled promise rejection", reason);
+});
+
+process.on("uncaughtException", (error) => {
+  console.error("Uncaught exception", error);
+});
+
 // Start Express server (binds to process.env.PORT)
 createServer();

--- a/server/src/routes/monitor-route.ts
+++ b/server/src/routes/monitor-route.ts
@@ -16,6 +16,7 @@ import { Router } from "express";
 import { parsedEnv } from "../utils/env-validation";
 import { getJwtInfo } from "../middleware/jwtAuth";
 import { getSessionStats } from "../utils/session-tracker";
+import redisClient from "../utils/redis-client";
 
 const router = Router();
 
@@ -36,6 +37,10 @@ router.get("/health", (_req, res) => {
     uptime: process.uptime(),
     memory: process.memoryUsage(),
     version: process.version,
+    redis: {
+      configured: !!parsedEnv.REDIS_URL,
+      status: redisClient.getStatus(),
+    },
   });
 });
 

--- a/server/src/utils/redis-client.ts
+++ b/server/src/utils/redis-client.ts
@@ -1,33 +1,224 @@
-import { createClient, type RedisClientType } from "redis";
+import { createClient, type RedisClientType, type RedisFunctions, type RedisModules, type RedisScripts } from "redis";
+import { logger } from "./logger";
 
-const baseRedisClient: RedisClientType = createClient({
-  url: process.env.REDIS_URL,
+type BaseRedisClient = RedisClientType<RedisModules, RedisFunctions, RedisScripts>;
+
+const REDIS_CONNECT_TIMEOUT_MS = Number(process.env.REDIS_CONNECT_TIMEOUT_MS ?? "10000");
+const REDIS_KEEP_ALIVE_MS = Number(process.env.REDIS_KEEP_ALIVE_MS ?? "5000");
+const REDIS_MAX_RETRY_DELAY_MS = Number(process.env.REDIS_MAX_RETRY_DELAY_MS ?? "3000");
+const REDIS_MAX_RETRIES = Number(process.env.REDIS_MAX_RETRIES ?? "50");
+
+function sanitizeRedisUrl(rawUrl: string): string {
+  try {
+    const parsed = new URL(rawUrl);
+
+    if (parsed.password) {
+      parsed.password = "***";
+    }
+
+    if (parsed.username) {
+      parsed.username = "***";
+    }
+
+    return parsed.toString();
+  } catch {
+    return "[invalid redis url]";
+  }
+}
+
+function validateRedisUrl(redisUrl: string): void {
+  if (!redisUrl) {
+    return;
+  }
+
+  const safeUrl = sanitizeRedisUrl(redisUrl);
+
+  if (!/^rediss?:\/\//i.test(redisUrl)) {
+    logger.warn("REDIS_URL does not use redis:// or rediss://", {
+      redisUrl: safeUrl,
+    });
+    return;
+  }
+
+  const isSecureScheme = redisUrl.startsWith("rediss://");
+  const tlsHint = /tls|ssl|upstash|render\.com|aws|azure|gcp/i.test(redisUrl);
+
+  if (!isSecureScheme && tlsHint) {
+    logger.warn(
+      "REDIS_URL may require TLS but is configured with redis://. Consider rediss:// for managed providers.",
+      {
+        redisUrl: safeUrl,
+      },
+    );
+  }
+}
+
+const redisUrl = process.env.REDIS_URL;
+const redisDisabled = process.env.REDIS_DISABLED === "true" || !redisUrl;
+
+if (redisDisabled) {
+  logger.warn(
+    "Redis client is running in disabled mode (REDIS_URL missing or REDIS_DISABLED=true).",
+  );
+} else {
+  validateRedisUrl(redisUrl);
+}
+
+const baseRedisClient: BaseRedisClient = createClient({
+  ...(redisUrl ? { url: redisUrl } : {}),
+  socket: {
+    connectTimeout: REDIS_CONNECT_TIMEOUT_MS,
+    keepAlive: true,
+    keepAliveInitialDelay: REDIS_KEEP_ALIVE_MS,
+    reconnectStrategy: (retries) => {
+      if (retries >= REDIS_MAX_RETRIES) {
+        logger.error(
+          "Redis reconnect retries exhausted. Redis features remain in degraded mode.",
+          undefined,
+          { retries },
+        );
+        return false;
+      }
+
+      const nextDelay = Math.min(100 + retries * 100, REDIS_MAX_RETRY_DELAY_MS);
+      return nextDelay;
+    },
+  },
 });
 
-// Connect immediately and log success or failure
-baseRedisClient
-  .connect()
-  .then(() => console.log("✅ Redis client connected"))
-  .catch((err) => console.error("❌ Redis connection error:", err));
+baseRedisClient.on("error", (error) => {
+  logger.error("Redis client error event", error);
+});
 
-// Create a wrapper that maintains backward compatibility and proper typing
+baseRedisClient.on("ready", () => {
+  logger.info("Redis client is ready");
+});
+
+baseRedisClient.on("end", () => {
+  logger.warn("Redis connection ended");
+});
+
+baseRedisClient.on("reconnecting", () => {
+  logger.warn("Redis reconnecting");
+});
+
+let connectPromise: Promise<BaseRedisClient> | null = null;
+
+async function ensureRedisConnected(): Promise<BaseRedisClient | null> {
+  if (redisDisabled) {
+    return null;
+  }
+
+  if (baseRedisClient.isReady) {
+    return baseRedisClient;
+  }
+
+  if (baseRedisClient.isOpen) {
+    return baseRedisClient;
+  }
+
+  if (!connectPromise) {
+    connectPromise = baseRedisClient
+      .connect()
+      .then((client) => {
+        logger.info("Redis client connected");
+        return client;
+      })
+      .catch((error) => {
+        logger.error("Redis initial connect failed; continuing in degraded mode", error);
+        throw error;
+      })
+      .finally(() => {
+        connectPromise = null;
+      });
+  }
+
+  try {
+    return await connectPromise;
+  } catch {
+    return null;
+  }
+}
+
+void ensureRedisConnected();
+
 const redisClient = {
-  // Expose the native Redis client methods with proper typing
-  get: baseRedisClient.get.bind(baseRedisClient),
-  set: baseRedisClient.set.bind(baseRedisClient),
-  setEx: baseRedisClient.setEx.bind(baseRedisClient),
-  del: baseRedisClient.del.bind(baseRedisClient),
-
-  // Maintain backward compatibility for disconnect (return Promise)
-  async disconnect() {
-    return await baseRedisClient.disconnect();
+  async get(key: string) {
+    const client = await ensureRedisConnected();
+    if (!client) {
+      return null;
+    }
+    return client.get(key);
   },
 
-  // Expose other methods and properties for compatibility
-  isReady: baseRedisClient.isReady,
-  isOpen: baseRedisClient.isOpen,
-  connect: baseRedisClient.connect.bind(baseRedisClient),
-  sendCommand: baseRedisClient.sendCommand.bind(baseRedisClient),
+  async set(...args: Parameters<BaseRedisClient["set"]>) {
+    const client = await ensureRedisConnected();
+    if (!client) {
+      return null;
+    }
+    return client.set(...args);
+  },
+
+  async setEx(...args: Parameters<BaseRedisClient["setEx"]>) {
+    const client = await ensureRedisConnected();
+    if (!client) {
+      return null;
+    }
+    return client.setEx(...args);
+  },
+
+  async del(...args: Parameters<BaseRedisClient["del"]>) {
+    const client = await ensureRedisConnected();
+    if (!client) {
+      return 0;
+    }
+    return client.del(...args);
+  },
+
+  async sendCommand(...args: Parameters<BaseRedisClient["sendCommand"]>) {
+    const client = await ensureRedisConnected();
+    if (!client) {
+      throw new Error("Redis unavailable: sendCommand failed in degraded mode");
+    }
+    return client.sendCommand(...args);
+  },
+
+  async connect() {
+    return ensureRedisConnected();
+  },
+
+  async disconnect() {
+    if (!baseRedisClient.isOpen) {
+      return;
+    }
+
+    await baseRedisClient.disconnect();
+  },
+
+  get isReady() {
+    return baseRedisClient.isReady;
+  },
+
+  get isOpen() {
+    return baseRedisClient.isOpen;
+  },
+
+  getStatus() {
+    if (redisDisabled) {
+      return "disabled" as const;
+    }
+
+    if (baseRedisClient.isReady) {
+      return "ready" as const;
+    }
+
+    if (baseRedisClient.isOpen) {
+      return "connecting" as const;
+    }
+
+    return "down" as const;
+  },
 };
 
+export type RedisClientFacade = typeof redisClient;
 export default redisClient;


### PR DESCRIPTION
### Motivation
- Production processes were crashing from unhandled `@redis/client` socket errors, which bubbled to an unhandled EventEmitter `error` and terminated Node.
- The Redis client needed resilience (single shared client, guarded connect, reconnect/backoff, socket options) and TLS/URL validation to avoid misconfigured managed providers.
- Health / observability and minimal process-level safety nets were required so outages don’t produce silent crash loops.

### Description
- Reworked the shared Redis module into a resilient singleton facade at `server/src/utils/redis-client.ts` with socket tuning (`connectTimeout`, `keepAlive`, `keepAliveInitialDelay`) and a bounded `reconnectStrategy` to avoid aggressive/unbounded retries.
- Added mandatory lifecycle listeners on the raw client (`error`, `ready`, `end`, `reconnecting`) and explicit logging via the app logger to prevent unhandled emitter errors and improve diagnostics.
- Ensured single guarded connection attempts with a shared `connectPromise` and methods that operate in degraded mode (returning `null`/`0` where appropriate) when Redis is disabled/unavailable.
- Added safe `REDIS_URL` validation and sanitized warnings about TLS mismatches (recommend `rediss://` for managed providers) without logging secrets.
- Exposed `getStatus()` on the facade and surfaced Redis status in the health endpoint at `server/src/routes/monitor-route.ts` (added `redis.configured` and `redis.status`).
- Added process-level logging handlers for `unhandledRejection` and `uncaughtException` in `server/src/index.ts` to avoid silent crash loops while still surfacing errors.
- Minor typing/bridge in `server/src/config/rateLimiter.ts` so `rate-limit-redis` can call `sendCommand` on the facade.
- Updated README to document `REDIS_URL` TLS guidance and that the app boots in degraded mode if Redis is missing.
- Added/updated unit tests at `server/src/utils/__tests__/redis-client.test.ts` to validate lifecycle listener registration and degraded-mode behavior.

Modified files (key):
- `server/src/utils/redis-client.ts` (main changes)
- `server/src/routes/monitor-route.ts` (health status)
- `server/src/index.ts` (process-level handlers)
- `server/src/config/rateLimiter.ts` (sendCommand typing bridge)
- `server/src/utils/__tests__/redis-client.test.ts` (tests)
- `README.md` (env guidance)

### Testing
- Ran unit tests for the Redis client: `npm run test --workspace=server -- src/utils/__tests__/redis-client.test.ts` and all tests passed (5/5).
- Attempted full TypeScript build: `npm run build --workspace=server` failed due to an existing workspace TypeScript config/include issue around `@pagepersonai/shared` (this is unrelated to the Redis changes and pre-existed the patch).
- Attempted a local start: `npm run start --workspace=server` failed in this environment due to a missing `@pagepersonai/shared/dist/index.js` runtime artifact (also unrelated to the Redis changes).

Notes: the code now intentionally boots in degraded mode when `REDIS_URL` is not set or initial connection fails, avoiding process exits on Redis outages while logging explicit transition events; if a strictly-fail-fast behavior is required instead, that can be toggled by policy or environment variable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984aae25a948320812c55903659700f)